### PR TITLE
feat: add sigma band analysis and unify frequency band ranges

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.defaultInterpreterPath": "c:/Users/82105/Desktop/OneClick_Client_New/.venv/Scripts/python.exe"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.defaultInterpreterPath": "c:/Users/82105/Desktop/OneClick_Client_New/.venv/Scripts/python.exe"
-}

--- a/main.py
+++ b/main.py
@@ -50,36 +50,42 @@ def eeg_content_bulk(payload, name):
         'topography_alpha': payload['topography'][name]['alpha'],
         'topography_beta': payload['topography'][name]['beta'],
         'topography_gamma': payload['topography'][name]['gamma'],
+        'topography_sigma': payload['topography'][name]['sigma'],
         'connectivity_delta': payload['connectivity'][name]['delta'],
         'connectivity_theta': payload['connectivity'][name]['theta'],
         'connectivity_alpha': payload['connectivity'][name]['alpha'],
         'connectivity_beta': payload['connectivity'][name]['beta'],
         'connectivity_gamma': payload['connectivity'][name]['gamma'],
+        'connectivity_sigma': payload['connectivity'][name]['sigma'],
         'connectivity2_delta': payload['connectivity2'][name]['delta'],
         'connectivity2_theta': payload['connectivity2'][name]['theta'],
         'connectivity2_alpha': payload['connectivity2'][name]['alpha'],
         'connectivity2_beta': payload['connectivity2'][name]['beta'],
         'connectivity2_gamma': payload['connectivity2'][name]['gamma'],
+        'connectivity2_sigma': payload['connectivity2'][name]['sigma']
     }
 
 
-def eeg_diff_content_bulk(payload, name):
+def eeg_diff_content_bulk(payload, name): # sigma가 추가되어야 함
     return {
         'topography_delta': payload['topography_diff'][name]['delta'],
         'topography_theta': payload['topography_diff'][name]['theta'],
         'topography_alpha': payload['topography_diff'][name]['alpha'],
         'topography_beta': payload['topography_diff'][name]['beta'],
         'topography_gamma': payload['topography_diff'][name]['gamma'],
+        'topography_sigma': payload['topography_diff'][name]['sigma'],
         'connectivity_delta': payload['connectivity_diff'][name]['delta'],
         'connectivity_theta': payload['connectivity_diff'][name]['theta'],
         'connectivity_alpha': payload['connectivity_diff'][name]['alpha'],
         'connectivity_beta': payload['connectivity_diff'][name]['beta'],
         'connectivity_gamma': payload['connectivity_diff'][name]['gamma'],
+        'connectivity_sigma': payload['connectivity_diff'][name]['sigma'],
         'connectivity2_delta': payload['connectivity2_diff'][name]['delta'],
         'connectivity2_theta': payload['connectivity2_diff'][name]['theta'],
         'connectivity2_alpha': payload['connectivity2_diff'][name]['alpha'],
         'connectivity2_beta': payload['connectivity2_diff'][name]['beta'],
         'connectivity2_gamma': payload['connectivity2_diff'][name]['gamma'],
+        'connectivity2_sigma': payload['connectivity2_diff'][name]['sigma']
     }
 
 

--- a/utils/eeg/analysis.py
+++ b/utils/eeg/analysis.py
@@ -37,7 +37,7 @@ def main_analysis(path, trigger):
     eeg_info = mne.create_info(ch_names=ch_list, sfreq=sfreq, ch_types="eeg")
     data_ = mne.io.RawArray(eeg_data, info=eeg_info)
     data_.drop_channels(['O1', 'O2'])
-    filter_data = data_.copy().filter(l_freq=1, h_freq=60.)
+    filter_data = data_.copy().filter(l_freq=0.5, h_freq=60.)
 
     montage = mne.channels.make_standard_montage('standard_1020')
     filter_data.set_montage(montage)

--- a/utils/eeg/eeg_analysis/brain_connectivity.py
+++ b/utils/eeg/eeg_analysis/brain_connectivity.py
@@ -26,7 +26,7 @@ def get_brain_connectivity(epoch_data, uuid, type, trigger):
     sample_size = epoch_data.shape[0]
     step = sample_size // 5
     exp_names = ['baseline', 'stimulation1', 'recovery1', 'stimulation2', 'recovery2']
-    bands = {'delta': [0, 4], 'theta': [4, 8], 'alpha': [8, 13], 'beta': [13, 30], 'gamma': [30, 40]}
+    bands = {'delta': [0.5, 4], 'theta': [4, 8], 'alpha': [8, 12], 'beta': [12, 30], 'gamma': [30, 40], 'sigma': [12, 15]}
     files = {exp_name: {band_name: None for band_name in bands.keys()} for exp_name in exp_names}
 
     fc_method = type

--- a/utils/eeg/eeg_analysis/brain_connectivity_diff.py
+++ b/utils/eeg/eeg_analysis/brain_connectivity_diff.py
@@ -46,7 +46,7 @@ def get_diff_brain_connectivity(epoch_data, uuid, type, trigger):
     sample_size = epoch_data.shape[0]
     step = sample_size // 5
     exp_names = ['diff1', 'diff2', 'diff3', 'diff4']
-    bands = {'delta': [0, 4], 'theta': [4, 8], 'alpha': [8, 13], 'beta': [13, 30], 'gamma': [30, 40]}
+    bands = {'delta': [0.5, 4], 'theta': [4, 8], 'alpha': [8, 12], 'beta': [12, 30], 'gamma': [30, 40], 'sigma': [12, 15]}
     files = {exp_name: {band_name: None for band_name in bands.keys()} for exp_name in exp_names}
 
     epochs = []

--- a/utils/eeg/eeg_analysis/faa.py
+++ b/utils/eeg/eeg_analysis/faa.py
@@ -18,19 +18,13 @@ def get_frontal_alpha_asymmetry(epoch_data, uuid, trigger):
         idx_band = np.logical_and(frequencies >= low, frequencies < high)
         bp = simpson(psd[:, idx_band], dx=frequencies[1] - frequencies[0])
 
-        if True:
-            sum_ = 0
-            for level, (l, h) in enumerate([(0.5, 4), (4, 8), (8, 13), (13, 30)]):
-                idx = np.logical_and(frequencies >= l, frequencies < h)
-                if level == 0:
-                    sum_ = simpson(psd[:, idx], dx=frequencies[1] - frequencies[0])
-                else:
-                    sum_ += simpson(psd[:, idx], dx=frequencies[1] - frequencies[0])
-            bp /= sum_
+        idx = np.logical_and(frequencies>=0.5, frequencies<40)
+        sum_ = simpson(psd[:, idx], dx=frequencies[1]-frequencies[0])
+        bp /= sum_
         return bp
 
     def get_faa_func(data_, ch_names, sfreq):
-        alpha_band = (8, 13)
+        alpha_band = (8, 13) # 사용 안 됨
         l_channels, r_channels = ['Fp1', 'F7', 'F3'], ['Fp2', 'F4', 'F8']
         l_indices, r_indices = [ch_names.index(ch) for ch in l_channels], [ch_names.index(ch) for ch in r_channels]
 
@@ -39,8 +33,8 @@ def get_frontal_alpha_asymmetry(epoch_data, uuid, trigger):
         segment_l, segment_r = data_[:, l_indices, :], data_[:, r_indices, :]
         total_l_alpha, total_r_alpha = [], []
         for sl, sr in zip(segment_l, segment_r):
-            l_alpha = get_psd_analysis_func(sl, sfreq, low=8, high=13)
-            r_alpha = get_psd_analysis_func(sr, sfreq, low=8, high=13)
+            l_alpha = get_psd_analysis_func(sl, sfreq, low=8, high=12)
+            r_alpha = get_psd_analysis_func(sr, sfreq, low=8, high=12)
             total_l_alpha.append(l_alpha)
             total_r_alpha.append(r_alpha)
 

--- a/utils/eeg/eeg_analysis/fronto_limbic.py
+++ b/utils/eeg/eeg_analysis/fronto_limbic.py
@@ -26,7 +26,8 @@ def get_fronto_limbic_analysis(epoch_data, uuid):
         'theta': (4, 8),
         'alpha': (8, 12),
         'beta': (12, 30),
-        'gamma': (30, 49)
+        'gamma': (30, 40),
+        'sigma': (12, 15)
     }
 
     epoch_data = copy.deepcopy(epoch_data)
@@ -35,7 +36,7 @@ def get_fronto_limbic_analysis(epoch_data, uuid):
         filtered_data = copy.deepcopy(epoch_data)
         filtered_data = filtered_data.load_data().filter(l_freq=band_freqs[0], h_freq=band_freqs[1]).get_data()
         montage = mne.channels.make_standard_montage('standard_1020')
-        info = mne.create_info(wanted_ch_list, sfreq=125, ch_types='eeg')
+        info = mne.create_info(wanted_ch_list, sfreq=epoch_data.info['sfreq'], ch_types='eeg')
         info.set_montage(montage)
 
         matrix = compute_plv(filtered_data)
@@ -56,7 +57,7 @@ def get_fronto_limbic_analysis(epoch_data, uuid):
 
         for i in range(len(wanted_ch_list)):
             for j in range(i + 1, len(wanted_ch_list)):
-                weight = matrix[i, j]
+                weight = matrix[wanted_ch_indices[i], wanted_ch_indices[j]]
                 G.add_edge(wanted_ch_list[i], wanted_ch_list[j], weight=weight)
 
         edges = G.edges(data=True)

--- a/utils/eeg/eeg_analysis/psd.py
+++ b/utils/eeg/eeg_analysis/psd.py
@@ -9,27 +9,28 @@ def get_psd_analysis(epoch_data):
         idx_band = np.logical_and(freqs_ >= freq_range[0], freqs_ <= freq_range[1])
         bp = simpson(psds_[idx_band], dx=freq_res)
         # bp /= simpson(psds_, dx=freq_res)
-        full_band = np.logical_and(freqs_ >= 0, freqs_ <= 40)
+        full_band = np.logical_and(freqs_ >= 0.5, freqs_ <= 40)
         bp /= simpson(psds_[full_band], dx=freq_res)
         return bp
 
     epoch_data = copy.deepcopy(epoch_data)
-    raw_spectrum = epoch_data.compute_psd(method='welch', fmin=0, fmax=40)
+    raw_spectrum = epoch_data.compute_psd(method='welch', fmin=0.5, fmax=40)
     mean_spectrum = raw_spectrum.average()
     psds, freqs = mean_spectrum.get_data(return_freqs=True)
     psds = 10 * np.log10(psds)
     psds += np.abs(np.min(psds))
     psds_mean, psds_std = psds.mean(axis=0), psds.std(axis=0)
 
-    p1 = get_related_power(psds_mean, freqs, freq_range=[0, 4])
+    p1 = get_related_power(psds_mean, freqs, freq_range=[0.5, 4])
     p2 = get_related_power(psds_mean, freqs, freq_range=[4, 8])
     p3 = get_related_power(psds_mean, freqs, freq_range=[8, 12])
     p4 = get_related_power(psds_mean, freqs, freq_range=[12, 30])
     p5 = get_related_power(psds_mean, freqs, freq_range=[30, 40])
+    p6 = get_related_power(psds_mean, freqs, freq_range=[12, 15])
 
     result = {
         'raw_psd': {'mean': psds_mean, 'std': psds_std, 'freqs': freqs},
-        'related_psd': [p1, p2, p3, p4, p5],
+        'related_psd': [p1, p2, p3, p4, p5, p6],
         'region_psd': get_region_psd(epoch_data),
     }
     return result
@@ -41,7 +42,7 @@ def get_region_psd(epoch_data):
         idx_band = np.logical_and(freqs_ >= freq_range[0], freqs_ <= freq_range[1])
         bp = simpson(psds_[idx_band], dx=freq_res)
         # bp /= simpson(psds_, dx=freq_res)
-        full_band = np.logical_and(freqs_ >= 0, freqs_ <= 40)
+        full_band = np.logical_and(freqs_ >= 0.5, freqs_ <= 40)
         bp /= simpson(psds_[full_band], dx=freq_res)
         return bp
 
@@ -49,7 +50,7 @@ def get_region_psd(epoch_data):
     epoch_data = copy.deepcopy(epoch_data)
     ch_list = epoch_data.info['ch_names']
     sfreq = epoch_data.info['sfreq']
-    bands = {'delta': [0, 4], 'theta': [4, 8], 'alpha': [8, 13], 'beta': [13, 30], 'gamma': [30, 40]}
+    bands = {'delta': [0, 4], 'theta': [4, 8], 'alpha': [8, 13], 'beta': [13, 30], 'gamma': [30, 40]} # 사용되지 않음
     r_brain_region = ['Fp2', 'F8', 'F4', 'C4', 'T4', 'P4']
     l_brain_region = ['Fp1', 'F7', 'F3', 'C3', 'T3', 'P3']
     r_brain_region_idx = np.array([ch_list.index(ch_name) for ch_name in r_brain_region])
@@ -59,37 +60,38 @@ def get_region_psd(epoch_data):
     l_brain_eeg = mne.EpochsArray(epoch_data.get_data()[:, l_brain_region_idx, :],
                                   mne.create_info(ch_names=l_brain_region, sfreq=sfreq, ch_types="eeg"))
 
-    r_raw_spectrum = r_brain_eeg.compute_psd(method='welch', fmin=0, fmax=40)
+    r_raw_spectrum = r_brain_eeg.compute_psd(method='welch', fmin=0.5, fmax=40)
     r_mean_spectrum = r_raw_spectrum.average()
     r_psds, freqs = r_mean_spectrum.get_data(return_freqs=True)
     r_psds = 10 * np.log10(r_psds)
     r_psds += np.abs(np.min(r_psds))
     r_psds_mean = r_psds.mean(axis=0)
 
-    r_p1 = get_related_power(r_psds_mean, freqs, freq_range=[0, 4])
+    r_p1 = get_related_power(r_psds_mean, freqs, freq_range=[0.5, 4])
     r_p2 = get_related_power(r_psds_mean, freqs, freq_range=[4, 8])
     r_p3 = get_related_power(r_psds_mean, freqs, freq_range=[8, 12])
     r_p4 = get_related_power(r_psds_mean, freqs, freq_range=[12, 30])
     r_p5 = get_related_power(r_psds_mean, freqs, freq_range=[30, 40])
+    r_p6 = get_related_power(r_psds_mean, freqs, freq_range=[12, 15])
 
     # r_all = r_p1 + r_p2 + r_p3 + r_p4 + r_p5
     # r_p1, r_p2, r_p3, r_p4, r_p5 = r_p1/r_all, r_p2/r_all, r_p3/r_all, r_p4/r_all, r_p5/r_all
 
-    l_raw_spectrum = l_brain_eeg.compute_psd(method='welch', fmin=0, fmax=40)
+    l_raw_spectrum = l_brain_eeg.compute_psd(method='welch', fmin=0.5, fmax=40)
     l_mean_spectrum = l_raw_spectrum.average()
     l_psds, freqs = l_mean_spectrum.get_data(return_freqs=True)
     l_psds = 10 * np.log10(l_psds)
     l_psds += np.abs(np.min(l_psds))
     l_psds_mean = l_psds.mean(axis=0)
 
-    l_p1 = get_related_power(l_psds_mean, freqs, freq_range=[0, 4])
+    l_p1 = get_related_power(l_psds_mean, freqs, freq_range=[0.5, 4])
     l_p2 = get_related_power(l_psds_mean, freqs, freq_range=[4, 8])
     l_p3 = get_related_power(l_psds_mean, freqs, freq_range=[8, 12])
     l_p4 = get_related_power(l_psds_mean, freqs, freq_range=[12, 30])
     l_p5 = get_related_power(l_psds_mean, freqs, freq_range=[30, 40])
-
+    l_p6 = get_related_power(l_psds_mean, freqs, freq_range=[12, 15])
     # l_all = l_p1 + l_p2 + l_p3 + l_p4 + l_p5
     # l_p1, l_p2, l_p3, l_p4, l_p5 = l_p1 / l_all, l_p2 / l_all, l_p3 / l_all, l_p4 / l_all, l_p5 / l_all
 
-    result = {'right': [r_p1, r_p2, r_p3, r_p4, r_p5], 'left': [l_p1, l_p2, l_p3, l_p4, l_p5]}
+    result = {'right': [r_p1, r_p2, r_p3, r_p4, r_p5, r_p6], 'left': [l_p1, l_p2, l_p3, l_p4, l_p5, l_p6]}
     return result

--- a/utils/eeg/eeg_analysis/psd_diff.py
+++ b/utils/eeg/eeg_analysis/psd_diff.py
@@ -10,7 +10,7 @@ def get_psd_diff_analysis(epoch_data, uuid):
     from sklearn.preprocessing import StandardScaler
 
     def psd(raw, band_range):
-        spectrum = raw.compute_psd(method='welch', fmin=0.5, fmax=50)
+        spectrum = raw.compute_psd(method='welch', fmin=0.5, fmax=40)
         psds, freqs = spectrum.get_data(return_freqs=True)
         psds = 10 * np.log10(psds)
         psds_mean = psds.mean(axis=0)
@@ -35,7 +35,7 @@ def get_psd_diff_analysis(epoch_data, uuid):
     sample_size = epoch_data.shape[0]
     step = sample_size // 5
     exp_names = ['diff1', 'diff2', 'diff3', 'diff4']
-    freq_bands = {'delta': (0.5, 4), 'theta': (4, 8), 'alpha': (8, 12), 'beta': (12, 30), 'gamma': (30, 49)}
+    freq_bands = {'delta': (0.5, 4), 'theta': (4, 8), 'alpha': (8, 12), 'beta': (12, 30), 'gamma': (30, 40), 'sigma': (12, 15)}
     files = {exp_name: {band_name: None for band_name in freq_bands.keys()} for exp_name in exp_names}
 
     epochs = []

--- a/utils/eeg/eeg_analysis/psd_topography.py
+++ b/utils/eeg/eeg_analysis/psd_topography.py
@@ -15,7 +15,7 @@ def get_psd_topography(epoch_data, uuid, trigger):
     step = sample_size // 5
     
     exp_names = ['baseline', 'stimulation1', 'recovery1', 'stimulation2', 'recovery2']
-    bands = {'delta': [0, 4], 'theta': [4, 8], 'alpha': [8, 13], 'beta': [13, 30], 'gamma': [30, 40]}
+    bands = {'delta': [0.5, 4], 'theta': [4, 8], 'alpha': [8, 12], 'beta': [12, 30], 'gamma': [30, 40], 'sigma': [12, 15]}
     files = {exp_name: {band_name: None for band_name in bands.keys()} for exp_name in exp_names}
 
 


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>OneClick Sigma 밴드 분석 추가</h2>
<h3>1. Sigma Band 추가 및 Frequency 범위 통일</h3>
<p><strong>배경</strong></p>
<ul>
<li>각 분석 파일마다 band 범위가 하드코딩되어 있고, 파일 간 범위가 불일치하는 경우 존재</li>
<li>Sleep spindle 관련 sigma band (12–15 Hz) 분석 추가</li>
</ul>
<p><strong>통일된 frequency 범위</strong></p>
<pre><code>delta : 0.5 – 4  Hz
theta :   4 – 8  Hz
alpha :   8 – 12 Hz
beta  :  12 – 30 Hz
gamma :  30 – 40 Hz
sigma :  12 – 15 Hz
</code></pre>
<blockquote>
<ul>
<li><strong>delta 하한</strong>: 0.5 Hz 미만은 노이즈 우려로 제외</li>
<li><strong>alpha/beta 경계</strong>: 13 Hz와 12 Hz 혼재 → 12 Hz로 통일</li>
<li><strong>gamma 상한</strong>: 100 Hz down-sampling 이후 49 Hz 대신 40 Hz로 설정</li>
</ul>
</blockquote>
<p><strong>파일별 변경 사항</strong></p>

파일 | Function | 기존 범위 변경점 | JSON output 변경
-- | -- | -- | --
psd.py | get_psd_analysis | delta 하한 0 → 0.5, sigma 추가, compute_psd 범위 0–40 → 0.5–40 | ['psd']['related_psd']: band 5 → 6개
psd.py | get_region_psd | delta 하한 0 → 0.5, sigma 추가, compute_psd 범위 0–40 → 0.5–40 | ['psd']['region_psd']['right/left']: band 5 → 6개
psd_topography.py | get_psd_topography | alpha 상한 13 → 12, beta 하한 13 → 12, sigma 추가 | *.topography_sigma 이미지 5개 추가 (baseline, stimulation1/2, recovery1/2)
psd_diff.py | get_psd_diff_analysis | gamma 상한 49 → 40, sigma 추가 | diff*.topography_sigma 이미지 4개 추가
brain_connectivity.py | get_brain_connectivity | alpha 상한 13 → 12, beta 하한 13 → 12, sigma 추가 | *.connectivity_sigma, *.connectivity2_sigma 이미지 각 5개 추가
brain_connectivity_diff.py | get_diff_brain_connectivity | alpha 상한 13 → 12, beta 하한 13 → 12, sigma 추가 | diff*.connectivity_sigma, diff*.connectivity2_sigma 이미지 각 4개 추가
fronto_limbic.py | get_fronto_limbic_analysis | gamma 상한 49 → 40, sigma 추가 | frontal_limbic.sigma 이미지 추가
faa.py | get_frontal_alpha_asymmetry | alpha 상한 13 → 12 | 변경 없음


<hr>
<h3>2. 버그 수정 및 코드 보완</h3>
<h4>1) ⚠️ <code>analysis.py</code> — <code>main_analysis</code> filter 하한 수정</h4>
<p>Delta band 하한을 0.5 Hz로 설정했으나 <code>l_freq=1</code>로 인해 0.5–1 Hz 성분이 제거되고 있었음.</p>
<pre><code class="language-python"># before
filter_data = data_.copy().filter(l_freq=1, h_freq=60.)

# after
filter_data = data_.copy().filter(l_freq=0.5, h_freq=60.)
</code></pre>
<h4>2) <code>faa.py</code> — <code>get_psd_analysis_func</code> 코드 단순화</h4>
<p>Band별 루프를 제거하고 full band (0.5–40 Hz) 기준으로 단순화. 경계값 중복 제거.</p>
<pre><code class="language-python"># before
if True:
    sum_ = 0
    for level, (l, h) in enumerate([(0.5, 4), (4, 8), (8, 13), (13, 30)]):
        idx = np.logical_and(frequencies &gt;= l, frequencies &lt; h)
        if level == 0:
            sum_ = simpson(psd[:, idx], dx=frequencies[1] - frequencies[0])
        else:
            sum_ += simpson(psd[:, idx], dx=frequencies[1] - frequencies[0])
    bp /= sum_

# after
idx = np.logical_and(frequencies &gt;= 0.5, frequencies &lt; 40)
sum_ = simpson(psd[:, idx], dx=frequencies[1] - frequencies[0])
bp /= sum_
</code></pre>
<h4>3) <code>fronto_limbic.py</code> — <code>sfreq</code> 하드코딩 수정 (코드 일관성)</h4>
<p>전처리에서 100 Hz로 down-sampling됐으나 <code>sfreq=125</code>로 하드코딩되어 있었음. 결과에는 영향 없으나 일관성을 위해 수정.</p>
<pre><code class="language-python"># before
info = mne.create_info(wanted_ch_list, sfreq=125, ch_types='eeg')

# after
info = mne.create_info(wanted_ch_list, sfreq=epoch_data.info['sfreq'], ch_types='eeg')
</code></pre>
<h4>4) ⚠️ <code>fronto_limbic.py</code> — PLV matrix 인덱싱 오류 수정</h4>
<p><code>wanted_ch_indices</code>를 정의해놓고 matrix 참조 시 사용하지 않아, 잘못된 채널의 PLV 값이 그래프에 반영되고 있었음.</p>
<pre><code class="language-python"># before
weight = matrix[i, j]

# after
weight = matrix[wanted_ch_indices[i], wanted_ch_indices[j]]
</code></pre></body></html><!--EndFragment-->
</body>
</html>